### PR TITLE
Sprint-2/debug/address.js: Add bracket notation for object property access example

### DIFF
--- a/Sprint-2/debug/address.js
+++ b/Sprint-2/debug/address.js
@@ -14,4 +14,15 @@ const address = {
 
 // You can't get values from objects using indexes, you need to reference a key in the object
 
+// To reference object key you can have two notations:
+
+// object.key
+// object['key']
+
+// Bracket notation is useful when your property name has spaces or it is a variable.
+
 console.log(`My house number is ${address.houseNumber}`);
+
+// or
+
+console.log(`My house number is ${address['houseNumber']}`);


### PR DESCRIPTION
This PR adds example with accessing object property with bracket notation. The original "buggy" code had `object[0]` which is wrong only in terms of accessing property by `index` as for arrays, but it is not buggy in terms of brackets `[]` which can be actually used in accessing object property.

I decided to add this as an example to solutions branch.  