### PR TITLE
Update tests for Sprint 1 'fix median' task

### DIFF
--- a/Sprint-1/fix/median.js
+++ b/Sprint-1/fix/median.js
@@ -2,6 +2,9 @@
 // Start by running the tests for this function
 // If you're in the Sprint-1 directory, you can run `npm test -- fix` to run the tests in the fix directory
 
+// Hint: Please consider scenarios when 'list' doesn't have numbers (the function is expected to return null)
+// or 'list' has mixed values (the function is expected to sort only numbers).
+
 function calculateMedian(list) {
   const middleIndex = Math.floor(list.length / 2);
   const median = list.splice(middleIndex, 1)[0];

--- a/Sprint-1/fix/median.test.js
+++ b/Sprint-1/fix/median.test.js
@@ -7,20 +7,42 @@
 const calculateMedian = require("./median.js");
 
 describe("calculateMedian", () => {
-  test("returns the median for odd length array", () => {
-    expect(calculateMedian([1, 2, 3])).toEqual(2);
-    expect(calculateMedian([1, 2, 3, 4, 5])).toEqual(3);
-  });
+  [
+    { input: [1, 2, 3], expected: 2 },
+    { input: [1, 2, 3, 4, 5], expected: 3 },
+    { input: [1, 2, 3, 4], expected: 2.5 },
+    { input: [1, 2, 3, 4, 5, 6], expected: 3.5 },
+  ].forEach(({ input, expected }) =>
+    it(`returns the median for [${input}]`, () => expect(calculateMedian(input)).toEqual(expected))
+  );
 
-  test("returns the average of middle values for even length array", () => {
-    expect(calculateMedian([1, 2, 3, 4])).toEqual(2.5);
-    expect(calculateMedian([1, 2, 3, 4, 5, 6])).toEqual(3.5);
-  });
+  [
+    { input: [3, 1, 2], expected: 2 },
+    { input: [5, 1, 3, 4, 2], expected: 3 },
+    { input: [4, 2, 1, 3], expected: 2.5 },
+    { input: [6, 1, 5, 3, 2, 4], expected: 3.5 },
+  ].forEach(({ input, expected }) =>
+    it(`returns the correct median for unsorted array [${input}]`, () => expect(calculateMedian(input)).toEqual(expected))
+  );
 
-  test("doesn't modify the input", () => {
+  it("doesn't modify the input array [1, 2, 3]", () => {
     const list = [1, 2, 3];
     calculateMedian(list);
-
     expect(list).toEqual([1, 2, 3]);
   });
+
+  [ 'not an array', 123, null, undefined, {}, [], ["apple", null, undefined] ].forEach(val =>
+    it(`returns null for non-numeric array (${val})`, () => expect(calculateMedian(val)).toBe(null))
+  );
+
+  [
+    { input: [1, 2, "3", null, undefined, 4], expected: 2 },
+    { input: ["apple", 1, 2, 3, "banana", 4], expected: 2.5 },
+    { input: [1, "2", 3, "4", 5], expected: 3 },
+    { input: [1, "apple", 2, null, 3, undefined, 4], expected: 2.5 },
+    { input: [3, "apple", 1, null, 2, undefined, 4], expected: 2.5 },
+    { input: ["banana", 5, 3, "apple", 1, 4, 2], expected: 3 },
+  ].forEach(({ input, expected }) =>
+    it(`filters out non-numeric values and calculates the median for [${input}]`, () => expect(calculateMedian(input)).toEqual(expected))
+  );
 });


### PR DESCRIPTION
This PR updates the tests for the fixed version of `median` function. The tests expect from the students to implement `median` function which will:

- Sort arrays, leaving only numeric values. Median can be calculated only on numeric values.
- Return `null` if no numeric values provided.

